### PR TITLE
make time display show correct 24h time

### DIFF
--- a/src/main/java/net/johnvictorfs/simple_utilities/hud/GameInfoHud.java
+++ b/src/main/java/net/johnvictorfs/simple_utilities/hud/GameInfoHud.java
@@ -151,7 +151,7 @@ public class GameInfoHud implements Drawable {
     }
 
     private static String parseTime(long time) {
-        long hours = time / 1000 + 6;
+        long hours = (time / 1000 + 6)%24;
         long minutes = (time % 1000) * 60 / 1000;
         String ampm = "AM";
 


### PR DESCRIPTION
On server, the time displayed was counting hours since world genesis, as shown in [this comment](https://www.curseforge.com/minecraft/mc-mods/simple-utilities?comment=1), this simply mod 24 the time so it's not dependent on how many in game days the world does exist