### PR TITLE
Compatibility for 1.18 snapshots

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version "0.8-SNAPSHOT"
+    id 'fabric-loom' version "0.9-SNAPSHOT"
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,12 +8,12 @@ archives_base_name = simple-hud-utilities
 
 # Fabric Properties
 # https://modmuss50.me/fabric.html?&version=1.17
-minecraft_version=21w44a
-yarn_mappings=21w44a+build.1
+minecraft_version=1.18-pre1
+yarn_mappings=1.18-pre1+build.3
 loader_version=0.11.7
 
 #Fabric api
-fabric_version=0.41.4+1.18
+fabric_version=0.42.2+1.18
 
 # Libraries
 cloth_config_version = 5.0.34

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,20 +2,20 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-mod_version = 2.2.0
+mod_version = 2.3.0
 maven_group = net.fabricmc
 archives_base_name = simple-hud-utilities
 
 # Fabric Properties
 # https://modmuss50.me/fabric.html?&version=1.17
-minecraft_version=1.17
-yarn_mappings=1.17+build.10
-loader_version=0.11.3
+minecraft_version=21w44a
+yarn_mappings=21w44a+build.1
+loader_version=0.11.7
 
 #Fabric api
-fabric_version=0.35.1+1.17
+fabric_version=0.41.4+1.18
 
 # Libraries
 cloth_config_version = 5.0.34
 auto_config_version = 3.3.1
-modmenu_version = 2.0.2
+modmenu_version = 3.0.0

--- a/src/main/java/net/johnvictorfs/simple_utilities/config/ModMenuIntegration.java
+++ b/src/main/java/net/johnvictorfs/simple_utilities/config/ModMenuIntegration.java
@@ -1,7 +1,7 @@
 package net.johnvictorfs.simple_utilities.config;
 
-import io.github.prospector.modmenu.api.ConfigScreenFactory;
-import io.github.prospector.modmenu.api.ModMenuApi;
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
 import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;


### PR DESCRIPTION
You might also create a 1.18 branch, if you merge it.

Needed to update the modmenu namespace.
Should build using java 16 and gradle.