### PR TITLE
Fix support for ClothConfig/ModMenu

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,13 +37,6 @@ dependencies {
         exclude(group: "net.fabricmc.fabric-api")
     }
 
-    modApi("me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}") {
-        exclude(group: "net.fabricmc.fabric-api")
-    }
-    include("me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}") {
-        exclude(group: "net.fabricmc.fabric-api")
-    }
-
     modImplementation("com.terraformersmc:modmenu:${project.modmenu_version}") {
         exclude(group: "net.fabricmc.fabric-api")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,5 @@ loader_version=0.14.8
 fabric_version=0.56.1+1.19
 
 # Libraries
-cloth_config_version = 5.0.34
-auto_config_version = 3.3.1
+cloth_config_version = 7.0.65
 modmenu_version = 4.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-mod_version = 2.5.0
+mod_version = 2.5.1
 maven_group = net.fabricmc
 archives_base_name = simple-hud-utilities
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/src/main/java/net/johnvictorfs/simple_utilities/SimpleUtilities.java
+++ b/src/main/java/net/johnvictorfs/simple_utilities/SimpleUtilities.java
@@ -1,8 +1,8 @@
 package net.johnvictorfs.simple_utilities;
 
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
-import me.sargunvohra.mcmods.autoconfig1u.ConfigHolder;
-import me.sargunvohra.mcmods.autoconfig1u.serializer.Toml4jConfigSerializer;
+import me.shedaniel.autoconfig.AutoConfig;
+import me.shedaniel.autoconfig.ConfigHolder;
+import me.shedaniel.autoconfig.serializer.Toml4jConfigSerializer;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;

--- a/src/main/java/net/johnvictorfs/simple_utilities/config/ModMenuIntegration.java
+++ b/src/main/java/net/johnvictorfs/simple_utilities/config/ModMenuIntegration.java
@@ -2,7 +2,7 @@ package net.johnvictorfs.simple_utilities.config;
 
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screen.Screen;

--- a/src/main/java/net/johnvictorfs/simple_utilities/config/SimpleUtilitiesConfig.java
+++ b/src/main/java/net/johnvictorfs/simple_utilities/config/SimpleUtilitiesConfig.java
@@ -1,8 +1,8 @@
 package net.johnvictorfs.simple_utilities.config;
 
-import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
-import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
-import me.sargunvohra.mcmods.autoconfig1u.annotation.ConfigEntry;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
 import net.johnvictorfs.simple_utilities.helpers.Colors;
 
 @Config(name = "simple_utilities")

--- a/src/main/java/net/johnvictorfs/simple_utilities/hud/GameInfoHud.java
+++ b/src/main/java/net/johnvictorfs/simple_utilities/hud/GameInfoHud.java
@@ -1,7 +1,7 @@
 package net.johnvictorfs.simple_utilities.hud;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.johnvictorfs.simple_utilities.config.SimpleUtilitiesConfig;
 import net.johnvictorfs.simple_utilities.helpers.Colors;
 import com.google.common.collect.Lists;


### PR DESCRIPTION
**The reasoning for this PR:** 
- The ModMenu for Simple HUD Utilities no longer appears after the latest release of V 2.5.0
- Users can't use ModMenu/CothConfig to edit their Simple Hud Util config

**Changes addressed in this PR:**

1. AutoConfig is now maintained and part of the **ClothConfig** project, all dependencies on the old package are updated
2. Incremented version number to **2.5.1** as this is a hotfix and contains no new features


**You can find mentioned where the AutoConfig dependency was taken over by ClothConfig here:**
https://www.curseforge.com/minecraft/mc-mods/auto-config-updated-api

**Found the issue from these comments on CurseForge:**
![image](https://user-images.githubusercontent.com/40410913/175793306-32ec2c48-ebd3-4271-a17e-61ad8834a6e7.png)

**Image showing that the Settings icon is now visible again with ModMenu:**
![java_sQJsdxCXZO](https://user-images.githubusercontent.com/40410913/175793460-411df837-4e26-4d8f-be80-781c17fdb8b7.png)

