### PR TITLE
Round down coordinates

### DIFF
--- a/src/main/java/net/johnvictorfs/simple_utilities/hud/GameInfoHud.java
+++ b/src/main/java/net/johnvictorfs/simple_utilities/hud/GameInfoHud.java
@@ -257,8 +257,8 @@ public class GameInfoHud {
             String direction = translatedDirection + " " + getOffset(facing);
 
             if (config.statusElements.toggleCoordinatesStatus) {
-                String coordsFormat = "%.0f, %.0f, %.0f";
-                coordDirectionStatus += String.format(coordsFormat, this.player.getX(), this.player.getY(), this.player.getZ());
+                String coordsFormat = "%d, %d, %d";
+                coordDirectionStatus += String.format(coordsFormat, (int) this.player.getX(), (int) this.player.getY(), (int) this.player.getZ());
 
                 if (config.statusElements.toggleDirectionStatus) {
                     coordDirectionStatus += " (" + direction + ")";


### PR DESCRIPTION
Following Issue #50 

The idea is to round down the coordinates, so it shows the actual block you are in instead of changing the coordinate halfway when crossing a block. This way matches the debug (F3) screen and the coordinates shown are a bit more intuitive.

Let me know if I should bump the version number.