### PR TITLE
New automatic release workflow for GitHub, Modrinth and CurseForge

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: New Additions
+      labels:
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'java' ]
+        java: [ 17 ]
+        os: [ ubuntu-20.04 ]
 
     steps:
     - name: Checkout repository
@@ -32,17 +34,20 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
 
-    # Autobuild attempts to build any compiled languages
-    # If this step fails, then you should remove it and run the build manually
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    - name: validate gradle wrapper
+      uses: gradle/wrapper-validation-action@v1
+
+    - name: setup jdk ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+
+    - name: make gradle wrapper executable
+      run: chmod +x ./gradlew
+
+    - name: build
+      run: ./gradlew build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Publish Release
+on:
+  push:
+    tags: v[0-9]+.[0-9]+.[0-9]+-[1-9]+.[0-9]+.[0-9]+
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [ 17 ]
+        os: [ ubuntu-20.04 ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v2
+
+      - name: validate gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: setup jdk ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: make gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: build
+        run: ./gradlew build
+
+      - name: Set mod version
+        id: mod_version
+        run: |
+          MOD_VERSION=$(grep 'mod_version' gradle.properties | cut -f2- -d= | sed -e 's/^[[:space:]]*//')
+          echo "::set-output name=MOD_VERSION::$MOD_VERSION"
+
+      - name: Create new releases for GitHub, Modrinth and CurseForge
+        uses: Kir-Antipov/mc-publish@v3.1
+        with:
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: Simple HUD Utilities ${{ steps.mod_version.outputs.MOD_VERSION }}
+          github-generate-changelog: true
+          github-discussion: Announcements

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -40,5 +40,11 @@
   },
   "suggests": {
     "modmenu": ">=4.0.0"
+  },
+  "custom": {
+    "modmanager": {
+      "curseforge": 356722,
+      "modrinth": "Mn86JBmJ"
+    }
   }
 }


### PR DESCRIPTION
Creating a new tag with the format `vX.Y.Z` (example: `v4.3.2`) with an updated `mod_id` in the `fabric.mod.json` file automatically builds an artifact with the new version, creates a GitHub, Modrinth and Curseforge releases with it

Also fixes newly setup [CodeQL analysis build](https://github.com/johnvictorfs/simple-utilities-mod/runs/7827559628?check_suite_focus=true)